### PR TITLE
Add broadcast_discover command

### DIFF
--- a/pentest.rb
+++ b/pentest.rb
@@ -1038,6 +1038,7 @@ class Plugin::Pentest < Msf::Plugin
     # Define Commands
     def commands
       {
+        "broadcast_discover"     => "Performs a Nmap broadcast scan for non pivot networks.",
         "network_discover"       => "Performs a port-scan and enumeration of services found for non pivot networks.",
         "discover_db"            => "Run discovery modules against current hosts in the database.",
         "show_session_networks"  => "Enumerate the networks one could pivot thru Meterpreter in the active sessions.",
@@ -1352,6 +1353,13 @@ class Plugin::Pentest < Msf::Plugin
     end
 
 
+    # Broadcast Discovery command
+    def cmd_broadcast_discover(*args)
+      # Run Nmap broadcast scripts
+      run_nmap('-T4 --stats-every 5s --script broadcast --script-args=newtargets -sn')
+    end
+
+
     # Network Discovery command
     def cmd_network_discover(*args)
       # Variables
@@ -1445,10 +1453,10 @@ class Plugin::Pentest < Msf::Plugin
         # Run the nmap scan, this will populate the database with the hosts and services that will be processed by the discovery modules
         if scan_type =~ /-A/
           cmd_str = "#{scan_type} -T4 -p #{ports * ","} --max-rtt-timeout=500ms --initial-rtt-timeout=200ms --min-rtt-timeout=200ms --open --stats-every 5s #{range}"
-          run_porscan(cmd_str)
+          run_nmap(cmd_str)
         else
           cmd_str = "#{scan_type} -T4 -p #{udp_ports * ","} --max-rtt-timeout=500ms --initial-rtt-timeout=200ms --min-rtt-timeout=200ms --open --stats-every 5s #{range}"
-          run_porscan(cmd_str)
+          run_nmap(cmd_str)
         end
         # Get a list of the new hosts and services after the scan and extract the new services and hosts
         after_hosts = framework.db.workspace.hosts.where(state: "alive")
@@ -1592,7 +1600,7 @@ class Plugin::Pentest < Msf::Plugin
 
 
     # Run Nmap scan with values provided
-    def run_porscan(cmd_str)
+    def run_nmap(cmd_str)
       print_status("Running NMap with options #{cmd_str}")
       driver.run_single("db_nmap #{cmd_str}")
       return true


### PR DESCRIPTION
A suggestion.

This PR adds a `broadcast_discover` command to gather hosts using Nmap broadcast scripts.

This command will populate the `hosts` table with identified hosts.

This command will not populate `services`, regardless of whether the output from the Nmap broadcast scripts contains services. The script output is printed to console for review by the operator.

This command features no options or `-h` help.

This approach to host discovery thrives in a zeroconf environment and allows for fast discovery of populated subnets.

As an aside, `run_portscan` [sic] has been renamed to `run_nmap`.
